### PR TITLE
Fix typo on "Contact Us" page

### DIFF
--- a/source/about/contact.rst
+++ b/source/about/contact.rst
@@ -13,9 +13,9 @@ The Paper project handles most of our communication via IRC.
 
 You can join us on either of these two servers:
 
-* `#Paper on irc.spi.gt <https://irc.spi.gt/iris/?channels=paper>`_
+* `#paper on irc.spi.gt <https://irc.spi.gt/iris/?channels=paper>`_
 
-* `#Paper on irc.esper.net <https://webchat.esper.net/?channels=paper>`_
+* `#paper on irc.esper.net <https://webchat.esper.net/?channels=paper>`_
 
 Discord
 =======
@@ -31,7 +31,7 @@ Twitter
 We often tweet out version release notes, update notices, and other information
 via our Twitter page.
 
-* `@PaperPowerered <https://twitter.com/PaperPowered>`_
+* `@PaperPowered <https://twitter.com/PaperPowered>`_
 
 You should not DM or @ this account for support. It is not
 checked as regularly as the above locations.


### PR DESCRIPTION
Was looking at the page for some weird reason and noticed the typo on the Twitter handle. Also changed the IRC channel names to lower case.