### PR TITLE
Document anti-xray's use-permission

### DIFF
--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -861,7 +861,7 @@ anti-xray
     - **description**: Whether or not to obfuscate blocks touching lava.
 
 * use-permission
-    - **deafult**: false
+    - **default**: false
     - **description**: Whether or not to allow players with the ``paper.antixray.bypass`` permission to
       bypass anti-xray. Checking this permission is disabled by default as legacy permission plugins may
       struggle with the number of checks made. This should only be used with modern

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -863,9 +863,9 @@ anti-xray
 * use-permission
     - **deafult**: false
     - **description**: Whether or not to allow players with the ``paper.antixray.bypass`` permission to
-      bypass anti-xray. This is disabled by default as legacy permission plugins may
-      struggle with the number of checks made. Modern permission plugins such as
-      LuckPerms will not cause issues with this enabled.
+      bypass anti-xray. Checking this permission is disabled by default as legacy permission plugins may
+      struggle with the number of checks made. This should only be used with modern
+      permission plugins.
 
 * hidden-blocks
     - **default**: { gold_ore, iron_ore, coal_ore, lapis_ore, mossy_cobblestone,

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -862,7 +862,7 @@ anti-xray
 
 * use-permission
     - **deafult**: false
-    - **description**: Weather or not to allow players with the ``paper.antixray.bypass`` permission to
+    - **description**: Whether or not to allow players with the ``paper.antixray.bypass`` permission to
       bypass anti-xray. This is disabled by default as legacy permission plugins may
       struggle with the number of checks made. Modern permission plugins such as
       LuckPerms will not cause issues with this enabled.

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -860,11 +860,18 @@ anti-xray
     - **default**: false
     - **description**: Whether or not to obfuscate blocks touching lava.
 
+* use-permission
+    - **deafult**: false
+    - **description**: Weather or not to allow players with the ``paper.antixray.bypass`` permission to
+      bypass anti-xray. This is disabled by default as legacy permission plugins may
+      struggle with the number of checks made. Modern permission plugins such as
+      LuckPerms will not cause issues with this enabled.
+
 * hidden-blocks
-   - **default**: { gold_ore, iron_ore, coal_ore, lapis_ore, mossy_cobblestone,
-     obsidian, chest, diamond_ore, redstone_ore, clay, emerald_ore, ender_chest }
-   - **description**: List of blocks to be hidden in engine mode 1.
-   - **note**: This list is using Mojang server names *not* bukkit names.
+    - **default**: { gold_ore, iron_ore, coal_ore, lapis_ore, mossy_cobblestone,
+      obsidian, chest, diamond_ore, redstone_ore, clay, emerald_ore, ender_chest }
+    - **description**: List of blocks to be hidden in engine mode 1.
+    - **note**: This list is using Mojang server names *not* bukkit names.
 
 * replacement-blocks:
     - **default**: { stone, oak_planks }


### PR DESCRIPTION
Added documentation for PaperMC/Paper#4074. I also fixed the spacing for `hidden-blocks` below as I noticed it was incorrect, I did not check for correct spacing anywhere else.