### PR TITLE
Document undocumented config options.

### DIFF
--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -1088,8 +1088,8 @@ fix-wither-targeting-bug
 map-item-frame-cursor-limit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    - **default**: 128
-   - **description**: The number of cursors (markers) allowed per map. A large number of markers
-     may be used to lag clients.
+   - **description**: The number of cursors (markers) allowed per map. A
+     large number of cursors may be used to lag clients.
 
 seed-based-feature-search
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -28,6 +28,12 @@ Global Settings
 Global settings affect all worlds on the server as well as the core server
 functionality itself.
 
+use-display-name-in-quit-message
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* **default**: false
+* **description**: Sets whether the server should use the player's display name
+  in quit messages.
+
 verbose
 ~~~~~~~
 * **default**: false
@@ -68,6 +74,11 @@ max-joins-per-tick
 * **description**: Sets the maximum amount of players that may join the server
   in a single tick. If more players join, they will be postponed until later ticks
   to join.
+
+track-plugin-scoreboards
+~~~~~~~~~~~~~~~~~~~~~~~~
+* **default**: false
+* **description**: Whether the server should track plugin scoreboards with only dummy objectives. This is a breaking change, however provides a much more sensible default value.
 
 suggest-player-names-when-null-tab-completions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -430,7 +441,7 @@ duplicate-uuid-saferegen-delete-range
   many blocks, saferegen will delete all but 1 of them.
 
 phantoms-do-not-spawn-on-creative-players
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * **default**: true
 * **description**: Disables spawning of phantoms on players in creative mode
 
@@ -481,6 +492,18 @@ parrots-are-unaffected-by-player-movement
 * **description**: Makes parrots "sticky" so they do not fall off a player's
   shoulder when they move. Use crouch to shake them off.
 
+only-players-collide
+~~~~~~~~~~~~~~~~~~~~
+* **default**: false
+* **description**: Only calculate collisions if a player is one of the two entities
+  colliding.
+
+allow-vehicle-collisions
+~~~~~~~~~~~~~~~~~~~~~~~~
+* **default**: false
+* **description**: Whether vehicles should also be able to collide while
+  ``only-players-collide`` is enabled.
+
 allow-non-player-entities-on-scoreboards
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * **default**: false
@@ -501,6 +524,11 @@ portal-create-radius
 * **default**: 16
 * **description**: The maximum range the server will try to create a portal around
   when generating a new portal
+
+portal-search-vanilla-dimension-scaling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* **default**: true
+* **description**: Whether to apply vanilla dimension scaling to ``portal-search-radius``.
 
 disable-thunder
 ~~~~~~~~~~~~~~~
@@ -534,6 +562,14 @@ container-update-tick-rate
 * **default**: 1
 * **description**: The rate, in ticks, at which the server updates containers
   and inventories.
+
+fix-items-merging-through-walls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* **default**: false
+* **description**: Whether item merges should be raytraced to prevent items
+  merging through walls. Enabling this will incur a performance degradation.
+  This is only necessary when ``merge-radius.item`` (spigot.yml) is large
+  enough to merge items through walls.
 
 prevent-tnt-from-moving-in-water
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -687,6 +723,11 @@ game-mechanics
     - **description**: Instructs the server to ignore shooter velocity when
       calculating the velocity of a fired arrow.
 
+* disable-mob-spawner-spawn-egg-transformation
+    - **default**: false
+    - **description**: Whether to block players from changing the type of
+      mob spawners with a spawn egg.
+
 * fix-curing-zombie-villager-discount-exploit
     - **default**: true
     - **description**: Fixes the `exploit <https://bugs.mojang.com/browse/MC-181190>`_ used to gain massive discounts by infecting and curing a zombie villager.
@@ -721,6 +762,14 @@ max-growth-height
     - **default**: 3
     - **description**: Maximum height sugar cane / reeds blocks will naturally
       grow to.
+
+* bamboo
+    - **max**
+        - **default**: 16
+        - **description**: Maximum height bamboo will naturally grow to.
+    - **min**
+        - **default**: 11
+        - **description**: Minimum height bamboo will naturally grow to.
 
 fishing-time-range
 ~~~~~~~~~~~~~~~~~~
@@ -987,7 +1036,14 @@ entity-per-chunk-save-limit
 * arrow
    - **default**: -1
    - **description**:  Limits the number of arrows that are saved/loaded per chunks. A value of -1 disables this limit
-  
+
+unsupported-settings
+~~~~~~~~~~~~~~~~~~~~
+* fix-invulnerable-end-crystal-exploit
+    - **default**: true
+    - **description**: If set to true, the creation of
+      invulnerable end crystals will be allowed. Fixes `MC-108513 <https://bugs.mojang.com/browse/MC-108513>`_.
+
 portal-search-radius
 ~~~~~~~~~~~~~~~~~~~~
    - **default**: 128
@@ -1025,6 +1081,20 @@ fix-wither-targeting-bug
 ~~~~~~~~~~~~~~~~~~~~~~~~
    - **default**: false
    - **description**: Fixes the wither's targeting of players. See `MC-29274 <https://bugs.mojang.com/browse/MC-29274>`_.
+
+map-item-frame-cursor-limit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   - **default**: 128
+   - **description**: The number of cursors (markers) allowed per map. A large number of markers
+     may be used to lag clients.
+
+seed-based-feature-search
+~~~~~~~~~~~~~~~~~~~~~~~~~
+   - **default**: true
+   - **description**: Whether during feature searches the server should check that a chunk's biome (determined by
+     world seed) can support the feature before loading it. This greatly reduces the number of chunks
+     loaded during feature searches.
+   - **note**: This expects the full world to be generated with the same seed and generator.
 
 allow-using-signs-inside-spawn-protection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -1091,8 +1091,8 @@ map-item-frame-cursor-limit
 seed-based-feature-search
 ~~~~~~~~~~~~~~~~~~~~~~~~~
    - **default**: true
-   - **description**: Whether during feature searches the server should check that a chunk's biome (determined by
-     world seed) can support the feature before loading it. This greatly reduces the number of chunks
+   - **description**: Whether the server should check whether a chunk's biome (determined by world seed) can support
+     the desired feature before loading it during feature searches. This dramatically reduces the number of chunks
      loaded during feature searches.
    - **note**: This expects the full world to be generated with the same seed and generator.
 

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -20,7 +20,7 @@ their respective documentation pages.
     information here to be incomplete. If you cannot find what you're looking for
     or think something may be wrong, :doc:`../about/contact`
 
-    Last updated January 30th, 2021 for MC 1.16.5, Paper build #457
+    Last updated June 3rd, 2021 for MC 1.16.5, Paper build #762
 
 Global Settings
 ===============
@@ -1094,10 +1094,13 @@ map-item-frame-cursor-limit
 seed-based-feature-search
 ~~~~~~~~~~~~~~~~~~~~~~~~~
    - **default**: true
-   - **description**: Whether the server should check if a chunk's biome (determined by world seed) can support
-     the desired feature before loading it during feature searches. This dramatically reduces the number of chunks
+   - **description**: Whether the server should check if a chunk's biome
+     (determined by world seed) can support the desired feature before loading
+     it during feature searches. This dramatically reduces the number of chunks
      loaded during feature searches.
-   - **note**: This expects the full world to be generated with the same seed and generator.
+   - **note**: This assumes the seed and generator have remained unchanged.
+     If your seed or world generator has been changed, features will be
+     located incorrectly.
 
 allow-using-signs-inside-spawn-protection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -1044,7 +1044,7 @@ unsupported-settings
 ~~~~~~~~~~~~~~~~~~~~
 * fix-invulnerable-end-crystal-exploit
     - **default**: true
-    - **description**: If set to true, the creation of
+    - **description**: If set to false, the creation of
       invulnerable end crystals will be allowed. Fixes `MC-108513 <https://bugs.mojang.com/browse/MC-108513>`_.
 
 portal-search-radius

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -78,7 +78,10 @@ max-joins-per-tick
 track-plugin-scoreboards
 ~~~~~~~~~~~~~~~~~~~~~~~~
 * **default**: false
-* **description**: Whether the server should track plugin scoreboards with only dummy objectives. This is a breaking change, however provides a much more sensible default value.
+* **description**: Whether the server should track plugin scoreboards with only
+  dummy objectives. This is a breaking change, however provides a much more
+  sensible default value. Enabling this with plugins using many scoreboards will
+  incur a performance degradation.
 
 suggest-player-names-when-null-tab-completions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -569,10 +569,10 @@ container-update-tick-rate
 fix-items-merging-through-walls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * **default**: false
-* **description**: Whether item merges should be raytraced to prevent items
-  merging through walls. Enabling this will incur a performance degradation.
-  This is only necessary when ``merge-radius.item`` (spigot.yml) is large
-  enough to merge items through walls.
+* **description**: Whether items should be prevented from merging
+  through walls. Enabling this will incur a performance degradation.This is
+  only necessary when ``merge-radius.item`` (spigot.yml) is large enough to
+  merge items through walls.
 
 prevent-tnt-from-moving-in-water
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -1091,7 +1091,7 @@ map-item-frame-cursor-limit
 seed-based-feature-search
 ~~~~~~~~~~~~~~~~~~~~~~~~~
    - **default**: true
-   - **description**: Whether the server should check whether a chunk's biome (determined by world seed) can support
+   - **description**: Whether the server should check if a chunk's biome (determined by world seed) can support
      the desired feature before loading it during feature searches. This dramatically reduces the number of chunks
      loaded during feature searches.
    - **note**: This expects the full world to be generated with the same seed and generator.

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -79,7 +79,7 @@ track-plugin-scoreboards
 ~~~~~~~~~~~~~~~~~~~~~~~~
 * **default**: false
 * **description**: Whether the server should track plugin scoreboards with only
-  dummy objectives. This is a breaking change, however provides a much more
+  dummy objectives. This is a breaking change; however, it provides a much more
   sensible default value. Enabling this with plugins using many scoreboards will
   incur a performance degradation.
 


### PR DESCRIPTION
Adds documentation for:

* use-display-name-in-quit-message
* track-plugin-scoreboards
* map-item-frame-cursor-limit
* seed-based-feature-search
* only-players-collide
* allow-vehicle-collisions
* portal-search-vanilla-dimension-scaling
* fix-items-merging-through-walls
* disable-mob-spawner-spawn-egg-transformation
* fix-invulnerable-end-crystal-exploit
* max-growth-height.bamboo

which I believe to be the only currently undocumented config options in paper.yml. Also fixes a small warning during build.

I'm not so sure about my documentation of `use-display-name-in-quit-message` as it does not provide any more information than what you could get by reading the configuration name, however, I'm not sure of a better way to phrase it or what to add.