### PR TITLE
Use a more appropriate JAVA_HOME path

### DIFF
--- a/source/java-update/index.rst
+++ b/source/java-update/index.rst
@@ -234,7 +234,7 @@ trailing slash here):
 .. code-block:: console
 
     # echo <<EOF
-    export JAVA_HOME=/usr/lib/jvm/graalvm-ce-java16-20.3.0
+    export JAVA_HOME=/usr/lib/jvm/jdk-16.0.1+1
     export PATH=$JAVA_HOME/bin:"$PATH"
     EOF | tee /etc/profile.d/java.sh
     # chmod +x /etc/profile.d/java.sh


### PR DESCRIPTION
Apparently people are copy-pasting this without adjusting the path to the real one, lets just use the same directory name which was used before in the guide so that will at least match if they are copy pasting all of it instead of directly unpacking/adjusting the version numbers.