### PR TITLE
Update documentation for version 2 of the API

### DIFF
--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -219,6 +219,7 @@ naming of resources.
 .. code-block:: text
 
     content-type: application/java-archive
+    content-length: 17759028
     cache-control: public, max-age=14400, s-maxage=604800
     content-disposition: attachment; filename*=UTF-8''waterfall-1.16-430.jar
 

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -6,11 +6,11 @@ Downloads API
     Version 1 of the API has been deprecated as of November 24th, 2020.
 
     We encourage everyone to use the new version of the API as the
-    previous one will soon be removed.__
+    previous one will soon be removed.
 
 After months of requests (years in the case of a few hosting providers), PaperMC
 has added a downloads API to standardize download links and finding specific
-versions of Paper for specific versions of Minecraft.
+versions of our software for specific versions of Minecraft.
 
 It is a simple RESTful JSON API. Like most APIs it uses versioned endpoints;
 the current version is ``v2``. If any breaking changes are made it will be
@@ -57,7 +57,7 @@ Swagger docs
 ------------
 To view the full `v2` documentation, including example responses
 for all below-documented endpoints and an interactive request generator,
-please go to `<https://papermc.io/api/docs/>`
+please go to `<https://papermc.io/api/docs/>`_
 
 Overview
 --------
@@ -115,7 +115,7 @@ The final piece of the URL, `waterfall-1.16-430.jar` can be found by using the
 previously documented endpoint to obtain information about a build.
 
 Note that filenames are not guaranteed to follow the same naming format,
-and you query the API properly to get the name of each build.
+and you must query the API properly to get the name of each build.
 
 Downloads served in this way will include ``content-type``, ``content-length``,
 and ``content-disposition`` headers for proper identification, progress, and

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -5,7 +5,9 @@ Downloads API
 .. warning::
     Version 1 of the API has been deprecated as of November 24th, 2020.
 
-    To view the full `v2` documentation, please go to `<https://papermc.io/api/docs/>`__
+    To view the full `v2` documentation, including example responses
+    for all endpoints and an interactive request generator,
+    please go to `<https://papermc.io/api/docs/>`__
 
 After months of requests (years in the case of a few hosting providers), PaperMC
 has added a downloads API to standardize download links and finding specific
@@ -22,28 +24,30 @@ Unlike the v1 API, there is no API endpoint to simply fetch the latest jar.
 This is intentional, as it was previously used to make auto-updating servers
 which is not recommended and, in rare cases, can lead to world corruption.
 
-The new URLs give me weird filenames
-------------------------------------
-While downloads using the ``v2`` API should have reasonable names compared to
-that of ``v1``, the below instructions are kept for completion.
+Downloading from the command line
+---------------------------------
+Because the filenames given by the API include version numbers,
+start scripts will have to continuously change to match the filename.
+For this reason, it is recommended that you choose a consistent name,
+such as `paperclip.jar` or `waterfall.jar`, and save your downloads
+to that file. This also has the advantage of not cluttering up
+your server directories with unneeded previous versions.
 
-If you're using `curl` you can use the ``-JLO`` flags to make it use the
-server's suggested name rather than making up its own. Alternatively, you can
-use the ``-o`` flag by itself to specify your own name for the downloaded file
-(ex: ``curl -o paperclip.jar http://someurl``).
-For more information, please see `curl's own documentation <https://curl.haxx.se/docs/manpage.html>`_.
+If you're using `curl` you can use the ``-o`` flag by itself to specify
+your own name for the downloaded file (ex: ``curl -o paperclip.jar http://someurl``).
+For more information, please see
+`curl's own documentation <https://curl.haxx.se/docs/manpage.html>`_.
 
-If you're using `wget` you can add the ``--content-disposition`` flag on newer
-versions to use the server's suggested name rather than having wget make up its
-own name. You can also use the ``-O`` flag to specify your own name for the
-downloaded file. (ex: ``wget http://someurl -O paperclip.jar``)
-For more information, please see `wget's own documentation <https://www.gnu.org/software/wget/manual/wget.html>`_.
+If you're using `wget`, you can use the ``-O`` flag to specify your own name
+for the downloaded file. (ex: ``wget http://someurl -O paperclip.jar``)
+For more information, please see
+`wget's own documentation <https://www.gnu.org/software/wget/manual/wget.html>`_.
 
-Other tools may or may not make up their own names for files, and they may or
-may not have options for following the server's recommended name. You will have
-to consult those specific tools' documentation to determine how that is handled.
-You can always simply rename the file immediately after download if your
-preferred tool does not support it for some reason.
+Other tools may not use the above options, and may even choose their own names.
+You will have to consult those specific tools' documentation to determine how
+that is handled. You can always simply rename the file immediately after
+download if your preferred tool does not allow you to set the file name
+for some reason.
 
 ======================
 Endpoint Documentation
@@ -55,35 +59,8 @@ The downloads API is project-based, and downloads can be obtained via the follow
 Example getting a listing of available project versions for Waterfall:
 ``https://papermc.io/api/v2/projects/waterfall``
 
-.. code-block:: json
-
- {
-  "project_id": "waterfall",
-  "project_name": "Waterfall",
-  "version_groups": [
-    "1.11",
-    "1.12",
-    "1.13",
-    "1.14",
-    "1.15",
-    "1.16",
-    "1.17"
-  ],
-  "versions": [
-    "1.11",
-    "1.12",
-    "1.13",
-    "1.14",
-    "1.15",
-    "1.16",
-    "1.17"
-  ]
- }
-
-
-
 NOTE: The parent (``https://papermc.io/api``) does not currently enumerate the
-available API versions and will instead redirect to a usage page on the latest
+available API versions and will instead redirect to a usage page on the current
 version of the API.
 
 PROJECT
@@ -99,73 +76,12 @@ VERSION
 -------
 This will vary from project to project above. By accessing the API using just
 the project name (ex: ``https://papermc.io/api/v2/projects/paper``),
-the API will return an array of available versions and version groups.
-
-.. code-block:: json
-
- {
-  "project_id": "paper",
-  "project_name": "Paper",
-  "version_groups": [
-    "1.8",
-    "1.9",
-    "1.10",
-    "1.11",
-    "1.12",
-    "1.13",
-    "1.14",
-    "1.15",
-    "1.16"
-  ],
-  "versions": [
-    "1.8.8",
-    "1.9.4",
-    "1.10.2",
-    "1.11.2",
-    "1.12",
-    "1.12.1",
-    "1.12.2",
-    "1.13-pre7",
-    "1.13",
-    "1.13.1",
-    "1.13.2",
-    "1.14",
-    "1.14.1",
-    "1.14.2",
-    "1.14.3",
-    "1.14.4",
-    "1.15",
-    "1.15.1",
-    "1.15.2",
-    "1.16.1",
-    "1.16.2",
-    "1.16.3",
-    "1.16.4",
-    "1.16.5"
-  ]
- }
+the API will return an array of available versions (which includes
+minor releases) and version groups (which do not).
 
 These versions correspond to the version of Minecraft the software is targeting.
 For example, ``https://papermc.io/api/v2/projects/paper/versions/1.16.5``
 will return all build IDs targeting the 1.16.5 version of Minecraft.
-
-.. code-block:: json
- {
-  "project_id": "paper",
-  "project_name": "Paper",
-  "version": "1.16.5",
-  "builds": [
-    427,
-    428,
-    429,
-    430,
-    431,
-    432,
-    433,
-    434,
-    435
-  ]
- }
 
 BUILD
 --------
@@ -175,29 +91,6 @@ v2 of the API they will always be integers.
 
 For example, ``https://papermc.io/api/v2/projects/paper/versions/1.16.5/builds/435`` will return
 information about the build for 1.16.5 with the ID of 435.
-
-.. code-block:: json
-
- {
-  "project_id": "paper",
-  "project_name": "Paper",
-  "version": "1.16.5",
-  "build": 435,
-  "time": "2021-01-19T22:56:04.092Z",
-  "changes": [
-    {
-      "commit": "8aeb4c9c3f52fae23ebcca07e5d1a934dc774372",
-      "summary": "Correctly skip pathfinder ticks for inactive entities (#5085)",
-      "message": "Correctly skip pathfinder ticks for inactive entities (#5085)\n\nFixes #5083"
-    }
-  ],
-  "downloads": {
-    "application": {
-      "name": "paper-1.16.5-435.jar",
-      "sha256": "cb1703f41fc837687d81be94b0ca2f3f8af0707fccab0f7d83947fcaaf81c0b9"
-    }
-  }
- }
 
 DOWNLOAD
 --------

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -5,9 +5,8 @@ Downloads API
 .. warning::
     Version 1 of the API has been deprecated as of November 24th, 2020.
 
-    To view the full `v2` documentation, including example responses
-    for all endpoints and an interactive request generator,
-    please go to `<https://papermc.io/api/docs/>`__
+    We encourage everyone to use the new version of the API as the
+    previous one will soon be removed.__
 
 After months of requests (years in the case of a few hosting providers), PaperMC
 has added a downloads API to standardize download links and finding specific
@@ -21,7 +20,7 @@ function for some time until further announcements are made.
 I just want to download the latest jar
 --------------------------------------
 Unlike the v1 API, there is no API endpoint to simply fetch the latest jar.
-This is intentional, as it was previously used to make auto-updating servers
+This is intentional, as it had been primarily used to auto-update servers,
 which is highly discouraged.
 
 Downloading from the command line
@@ -52,6 +51,16 @@ for some reason.
 ======================
 Endpoint Documentation
 ======================
+
+
+Swagger docs
+------------
+To view the full `v2` documentation, including example responses
+for all below-documented endpoints and an interactive request generator,
+please go to `<https://papermc.io/api/docs/>`
+
+Overview
+--------
 
 The downloads API is project-based, and downloads can be obtained via the following format:
 ``https://papermc.io/api/v2/projects/{PROJECT}/versions/{VERSION}/builds/{BUILD}/downloads/{DOWNLOAD}``
@@ -104,6 +113,9 @@ you would access the following URL:
 
 The final piece of the URL, `waterfall-1.16-430.jar` can be found by using the
 previously documented endpoint to obtain information about a build.
+
+Note that filenames are not guaranteed to follow the same naming format,
+and you query the API properly to get the name of each build.
 
 Downloads served in this way will include ``content-type``, ``content-length``,
 and ``content-disposition`` headers for proper identification, progress, and

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -52,7 +52,7 @@ Endpoint Documentation
 The downloads API is project-based, and downloads can be obtained via the following format:
 ``https://papermc.io/api/v2/projects/{PROJECT}/versions/{VERSION}/builds/{BUILD}/downloads/{DOWNLOAD}``
 
-Example getting a listing of available project versions for waterfall:
+Example getting a listing of available project versions for Waterfall:
 ``https://papermc.io/api/v2/projects/waterfall``
 
 .. code-block:: json

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -3,9 +3,9 @@ Downloads API
 =============
 
 .. warning::
-    This page shows `v1` of the API which is deprecated as of November 24th, 2020.
+    Version 1 of the API has been deprecated as of November 24th, 2020.
 
-    To view the `v2` documentation, please go to `<https://papermc.io/api/docs/>`__
+    To view the full `v2` documentation, please go to `<https://papermc.io/api/docs/>`__
 
 After months of requests (years in the case of a few hosting providers), PaperMC
 has added a downloads API to standardize download links and finding specific
@@ -13,20 +13,19 @@ versions of Paper for specific versions of Minecraft.
 
 It is a simple RESTful JSON API. Like most APIs it uses versioned endpoints;
 the current version is ``v2``. If any breaking changes are made it will be
-incremented to ``v3`` and announced, with the old version continuing to function
-for some time until further announcements are made.
+incremented to ``v3`` and announced, with the old version continuing to
+function for some time until further announcements are made.
 
 I just want to download the latest jar
 --------------------------------------
 Unlike the v1 API, there is no API endpoint to simply fetch the latest jar.
-This is intentional, as it was previously used to make auto-updating servers which is not recommended
-and, in rare cases, can lead to world corruption.
+This is intentional, as it was previously used to make auto-updating servers
+which is not recommended and, in rare cases, can lead to world corruption.
 
 The new URLs give me weird filenames
 ------------------------------------
-`curl`, `wget`, and other command line tools make up their own file names based
-on the download URL. As the new URL uses standardized links for downloads, these
-tools come up with unfamiliar or "useless" names.
+While downloads using the `v2` API should have reasonable names compared to
+that of `v1`, the below instructions are kept for completion.
 
 If you're using `curl` you can use the ``-JLO`` flags to make it use the
 server's suggested name rather than making up its own. Alternatively, you can
@@ -53,7 +52,8 @@ Endpoint Documentation
 The downloads API is project-based, and downloads can be obtained via the following format:
 ``https://papermc.io/api/v2/projects/{PROJECT}/versions/{VERSION}/builds/{BUILD}/downloads/{DOWNLOAD}``
 
-Example getting a listing of available project versions for waterfall: ``https://papermc.io/api/v2/projects/waterfall``
+Example getting a listing of available project versions for waterfall:
+``https://papermc.io/api/v2/projects/waterfall``
 
 .. code-block:: json
 
@@ -98,8 +98,8 @@ of all available projects if accessed directly.
 VERSION
 ---------------
 This will vary from project to project above. By accessing the API using just
-the project name (ex: ``https://papermc.io/api/v2/projects/paper``), the API will return
-an array of available versions and version groups.
+the project name (ex: ``https://papermc.io/api/v2/projects/paper``),
+the API will return an array of available versions and version groups.
 
 .. code-block:: json
 
@@ -172,7 +172,7 @@ BUILD
 --------
 A specific build of the given project. These build versions correspond
 with the build IDs specified by the backend continuous integration tools. As of
-v1 of the API they will always be integers.
+v2 of the API they will always be integers.
 
 For example, ``https://papermc.io/api/v2/projects/paper/versions/1.16.5/builds/435`` will return
 information about the build for 1.16.5 with the ID of 435.

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -11,24 +11,16 @@ After months of requests (years in the case of a few hosting providers), PaperMC
 has added a downloads API to standardize download links and finding specific
 versions of Paper for specific versions of Minecraft.
 
-It is a simple RESTful JSON API. Like most APIs it uses versioned endpoints,
-the current version is ``v1``, if any breaking changes are made it will be
-incremented to ``v2`` and announced, with the old version continuing to function
+It is a simple RESTful JSON API. Like most APIs it uses versioned endpoints;
+the current version is ``v2``. If any breaking changes are made it will be
+incremented to ``v3`` and announced, with the old version continuing to function
 for some time until further announcements are made.
-
-Please note that although we have no plans to change the structure of the API in
-a breaking way, that it is still relatively new and we will likely be working
-through any problems or pain spots as they arise.
 
 I just want to download the latest jar
 --------------------------------------
-To download the latest jar, simply connect to `<https://papermc.io/api/v1/paper/1.16.3/latest/download>`__
-
-If you're looking for Waterfall, the name `paper` can be
-replaced with `waterfall`. Specific versions can also be
-used by replacing `1.16.4` with `1.12.2` or another version. For additional
-information about available endpoints, projects, and versions, please read
-further below.
+Unlike the v1 API, there is no API endpoint to simply fetch the latest jar.
+This is intentional, as it was previously used to make auto-updating servers which is not recommended
+and, in rare cases, can lead to world corruption.
 
 The new URLs give me weird filenames
 ------------------------------------
@@ -58,160 +50,168 @@ preferred tool does not support it for some reason.
 Endpoint Documentation
 ======================
 
-Requests made to the API should conform to the following pattern:
-``https://papermc.io/api/{API_VERSION}/{PROJECT_NAME}/{PROJECT_VERSION}/{BUILD_ID}/download``
+The downloads API is project-based, and downloads can be obtained via the following format:
+``https://papermc.io/api/v2/projects/{PROJECT}/versions/{VERSION}/builds/{BUILD}/downloads/{DOWNLOAD}``
 
-You may optionally append the static path ``/download`` to automatically be given
-a specific file. Generally, hitting a parent of an item will enumerate it. Cases
-where this is not true are documented below.
-
-Example getting a listing of available project versions for waterfall: ``https://papermc.io/api/v1/waterfall``
+Example getting a listing of available project versions for waterfall: ``https://papermc.io/api/v2/projects/waterfall``
 
 .. code-block:: json
 
  {
-  "project": "waterfall",
+  "project_id": "waterfall",
+  "project_name": "Waterfall",
+  "version_groups": [
+    "1.11",
+    "1.12",
+    "1.13",
+    "1.14",
+    "1.15",
+    "1.16",
+    "1.17"
+  ],
   "versions": [
-   "1.16",
-   "1.15",
-   "1.14",
-   "1.13",
-   "1.12",
-   "1.11"
+    "1.11",
+    "1.12",
+    "1.13",
+    "1.14",
+    "1.15",
+    "1.16",
+    "1.17"
   ]
  }
 
-API_VERSION
------------
-``v1`` - The initial launch version of the API.
+
 
 NOTE: The parent (``https://papermc.io/api``) does not currently enumerate the
-available API versions and will return a ``403 Forbidden`` if accessed
-directly.
+available API versions and will instead redirect to a usage page on the latest
+version of the API.
 
-PROJECT_NAME
+PROJECT
 ------------
 - ``paper`` - The PaperMC server implementation
 - ``waterfall`` - The Waterfall server proxy
+- ``travertine`` - The Travertine proxy; Waterfall, but supprting Minecraft 1.7. Now deprecated.
 
-NOTE: The parent (``https://papermc.io/api/v1``) does not currently enumerate the
-available project names and will return a ``404 Not Found`` if accessed
-directly.
+The parent (``https://papermc.io/api/v2/projects``) will return a list
+of all available projects if accessed directly.
 
-PROJECT_VERSION
+VERSION
 ---------------
 This will vary from project to project above. By accessing the API using just
-the project name (ex: ``https://papermc.io/api/v1/paper``), the API will return
-an array of supported versions.
+the project name (ex: ``https://papermc.io/api/v2/projects/paper``), the API will return
+an array of available versions and version groups.
 
 .. code-block:: json
 
  {
-  "project": "paper",
-  "versions": [
-    "1.16.4",
-    "1.16.3",
-    "1.16.2",
-    "1.16.1",
-    "1.15.2",
-    "1.15.1",
-    "1.15",
-    "1.14.4",
-    "1.14.3",
-    "1.14.2",
-    "1.14.1",
+  "project_id": "paper",
+  "project_name": "Paper",
+  "version_groups": [
+    "1.8",
+    "1.9",
+    "1.10",
+    "1.11",
+    "1.12",
+    "1.13",
     "1.14",
-    "1.13.2",
-    "1.13.1",
+    "1.15",
+    "1.16"
+  ],
+  "versions": [
+    "1.8.8",
+    "1.9.4",
+    "1.10.2",
+    "1.11.2",
+    "1.12",
+    "1.12.1",
+    "1.12.2",
     "1.13-pre7",
     "1.13",
-    "1.12.2",
-    "1.12.1",
-    "1.12",
-    "1.11.2",
-    "1.10.2",
-    "1.9.4",
-    "1.8.8"
+    "1.13.1",
+    "1.13.2",
+    "1.14",
+    "1.14.1",
+    "1.14.2",
+    "1.14.3",
+    "1.14.4",
+    "1.15",
+    "1.15.1",
+    "1.15.2",
+    "1.16.1",
+    "1.16.2",
+    "1.16.3",
+    "1.16.4",
+    "1.16.5"
   ]
  }
 
 These versions correspond to the version of Minecraft the software is targeting.
-For example, ``https://papermc.io/api/v1/paper/1.16.4`` will return all build IDs
-targeting the 1.16.4 version of Minecraft.
+For example, ``https://papermc.io/api/v2/projects/paper/versions/1.16.5``
+will return all build IDs targeting the 1.16.5 version of Minecraft.
 
 .. code-block:: json
-
+ 
  {
-  "project": "paper",
-  "version": "1.16.4",
-  "builds": {
-    "latest": "279",
-    "all": [
-      "279",
-      "278",
-      "277",
-      "276",
-      "275",
-      "274",
-      "273",
-      "272",
-      "271",
-      "270",
-      "269",
-      "268",
-      "267",
-      "266",
-      "265",
-      "264",
-      "263",
-      "262",
-      "261",
-      "260",
-      "259",
-      "258",
-      "257",
-      "256"
-    ]
-  }
+  "project_id": "paper",
+  "project_name": "Paper",
+  "version": "1.16.5",
+  "builds": [
+    427,
+    428,
+    429,
+    430,
+    431,
+    432,
+    433,
+    434,
+    435,
+  ]
  }
 
-BUILD_ID
+BUILD
 --------
 A specific build of the given project. These build versions correspond
 with the build IDs specified by the backend continuous integration tools. As of
 v1 of the API they will always be integers.
 
-For example, ``https://papermc.io/api/v1/paper/1.16.4/279`` will return
-information about the build for 1.16.4 with the ID of 279.
+For example, ``https://papermc.io/api/v2/projects/paper/versions/1.16.5/builds/435`` will return
+information about the build for 1.16.5 with the ID of 435.
 
 .. code-block:: json
 
  {
-  "project": "paper",
-  "version": "1.16.4",
-  "build": "279"
- }
-
-You can use the static keyword `latest` in place of a specific build in order to
-get the latest version for that specific release of minecraft.
-For example, ``https://papermc.io/api/v1/paper/1.16.4/latest`` will return info
-on the latest version of the Paper project for 1.16.4.
-
-.. code-block:: json
-
- {
-  "project": "paper",
-  "version": "1.16.4",
-  "build": "279"
+  "project_id": "paper",
+  "project_name": "Paper",
+  "version": "1.16.5",
+  "build": 435,
+  "time": "2021-01-19T22:56:04.092Z",
+  "changes": [
+    {
+      "commit": "8aeb4c9c3f52fae23ebcca07e5d1a934dc774372",
+      "summary": "Correctly skip pathfinder ticks for inactive entities (#5085)",
+      "message": "Correctly skip pathfinder ticks for inactive entities (#5085)\n\nFixes #5083"
+    }
+  ],
+  "downloads": {
+    "application": {
+      "name": "paper-1.16.5-435.jar",
+      "sha256": "cb1703f41fc837687d81be94b0ca2f3f8af0707fccab0f7d83947fcaaf81c0b9"
+    }
+  }
  }
 
 DOWNLOAD
 --------
-Finally, if you want to download a version of something, you can simply append
-``/download`` to the URL path in order to be served a file.
+Finally, if you want to download a version of something, you must append
+the name of the file to download to the URL format in the example above.
 
-For example, to download the latest version of the Waterfall project for 1.16,
-you would access ``https://papermc.io/api/v1/waterfall/1.16/latest/download``
+For example, to download build 430 of the Waterfall project for 1.16,
+you would access the following URL:
+
+``https://papermc.io/api/v2/projects/waterfall/versions/1.16/builds/430/downloads/waterfall-1.16-430.jar``
+
+The final piece of the URL, `waterfall-1.16-430.jar` can be found by using the
+previously documented endpoint to obtain information about a build.
 
 Downloads served in this way will include ``content-type``, ``content-length``,
 and ``content-disposition`` headers for proper identification, progress, and
@@ -220,5 +220,11 @@ naming of resources.
 .. code-block:: text
 
     content-type: application/java-archive
-    content-length: 13713179
-    content-disposition: attachment; filename=waterfall-384.jar
+    cache-control: public, max-age=14400, s-maxage=604800
+    content-disposition: attachment; filename*=UTF-8''waterfall-1.16-430.jar
+
+API Versions
+--------------
+``v1`` - The initial launch version of the API, now deprecated.
+
+``v2`` - The current version of the API recommended for all usage.

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -90,7 +90,7 @@ PROJECT
 -------
 - ``paper`` - The PaperMC server implementation
 - ``waterfall`` - The Waterfall server proxy
-- ``travertine`` - The Travertine proxy; Waterfall, but supprting Minecraft 1.7. Now deprecated.
+- ``travertine`` - The Travertine proxy; Waterfall, but supporting Minecraft 1.7. Now deprecated.
 
 The parent (``https://papermc.io/api/v2/projects``) will return a list
 of all available projects if accessed directly.

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -96,7 +96,7 @@ The parent (``https://papermc.io/api/v2/projects``) will return a list
 of all available projects if accessed directly.
 
 VERSION
----------------
+-------
 This will vary from project to project above. By accessing the API using just
 the project name (ex: ``https://papermc.io/api/v2/projects/paper``),
 the API will return an array of available versions and version groups.

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -22,7 +22,7 @@ I just want to download the latest jar
 --------------------------------------
 Unlike the v1 API, there is no API endpoint to simply fetch the latest jar.
 This is intentional, as it was previously used to make auto-updating servers
-which is not recommended and, in rare cases, can lead to world corruption.
+which is highly discouraged.
 
 Downloading from the command line
 ---------------------------------

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -24,8 +24,8 @@ which is not recommended and, in rare cases, can lead to world corruption.
 
 The new URLs give me weird filenames
 ------------------------------------
-While downloads using the `v2` API should have reasonable names compared to
-that of `v1`, the below instructions are kept for completion.
+While downloads using the ``v2`` API should have reasonable names compared to
+that of ``v1``, the below instructions are kept for completion.
 
 If you're using `curl` you can use the ``-JLO`` flags to make it use the
 server's suggested name rather than making up its own. Alternatively, you can

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -150,7 +150,6 @@ For example, ``https://papermc.io/api/v2/projects/paper/versions/1.16.5``
 will return all build IDs targeting the 1.16.5 version of Minecraft.
 
 .. code-block:: json
- 
  {
   "project_id": "paper",
   "project_name": "Paper",

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -224,7 +224,7 @@ naming of resources.
     content-disposition: attachment; filename*=UTF-8''waterfall-1.16-430.jar
 
 API Versions
---------------
+------------
 ``v1`` - The initial launch version of the API, now deprecated.
 
 ``v2`` - The current version of the API recommended for all usage.

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -84,7 +84,7 @@ For example, ``https://papermc.io/api/v2/projects/paper/versions/1.16.5``
 will return all build IDs targeting the 1.16.5 version of Minecraft.
 
 BUILD
---------
+-----
 A specific build of the given project. These build versions correspond
 with the build IDs specified by the backend continuous integration tools. As of
 v2 of the API they will always be integers.

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -164,7 +164,7 @@ will return all build IDs targeting the 1.16.5 version of Minecraft.
     432,
     433,
     434,
-    435,
+    435
   ]
  }
 

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -87,7 +87,7 @@ available API versions and will instead redirect to a usage page on the latest
 version of the API.
 
 PROJECT
-------------
+-------
 - ``paper`` - The PaperMC server implementation
 - ``waterfall`` - The Waterfall server proxy
 - ``travertine`` - The Travertine proxy; Waterfall, but supprting Minecraft 1.7. Now deprecated.

--- a/source/site/api.rst
+++ b/source/site/api.rst
@@ -68,11 +68,12 @@ The downloads API is project-based, and downloads can be obtained via the follow
 Example getting a listing of available project versions for Waterfall:
 ``https://papermc.io/api/v2/projects/waterfall``
 
-NOTE: The parent (``https://papermc.io/api``) does not currently enumerate the
-available API versions and will instead redirect to a usage page on the current
-version of the API.
+.. hint::
+  The parent (``https://papermc.io/api``) does not currently enumerate the
+  available API versions and will instead redirect to a usage page on the current
+  version of the API.
 
-PROJECT
+Project
 -------
 - ``paper`` - The PaperMC server implementation
 - ``waterfall`` - The Waterfall server proxy
@@ -81,7 +82,7 @@ PROJECT
 The parent (``https://papermc.io/api/v2/projects``) will return a list
 of all available projects if accessed directly.
 
-VERSION
+Version
 -------
 This will vary from project to project above. By accessing the API using just
 the project name (ex: ``https://papermc.io/api/v2/projects/paper``),
@@ -92,7 +93,7 @@ These versions correspond to the version of Minecraft the software is targeting.
 For example, ``https://papermc.io/api/v2/projects/paper/versions/1.16.5``
 will return all build IDs targeting the 1.16.5 version of Minecraft.
 
-BUILD
+Build
 -----
 A specific build of the given project. These build versions correspond
 with the build IDs specified by the backend continuous integration tools. As of
@@ -101,7 +102,7 @@ v2 of the API they will always be integers.
 For example, ``https://papermc.io/api/v2/projects/paper/versions/1.16.5/builds/435`` will return
 information about the build for 1.16.5 with the ID of 435.
 
-DOWNLOAD
+Download
 --------
 Finally, if you want to download a version of something, you must append
 the name of the file to download to the URL format in the example above.


### PR DESCRIPTION
Even if these docs are not used, the v1 docs should be removed to prevent people from ignoring the deprecation notice and using it.
I probably missed a few things, and went over the 80 character line limit a few times, so I don't expect this to be merged as-is.