### PR TITLE
Add our own guide for Debian AdoptOpenJDK

### DIFF
--- a/source/java-update/index.rst
+++ b/source/java-update/index.rst
@@ -149,11 +149,11 @@ based on these, execute the following commands to add the AdoptOpenJDK APT repos
 
 .. code-block:: console
 
-    sudo apt update
-    sudo apt install apt-transport-https software-properties-common gnupg wget
-    wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
-    sudo add-apt-repository https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-    sudo apt install adoptopenjdk-16-hotspot
+    $ sudo apt update
+    $ sudo apt install apt-transport-https software-properties-common gnupg wget
+    $ wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+    $ sudo add-apt-repository https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+    $ sudo apt install adoptopenjdk-16-hotspot
     
 You can also replace ``16`` with ``11`` for Java 11.
 

--- a/source/java-update/index.rst
+++ b/source/java-update/index.rst
@@ -150,7 +150,7 @@ based on these, execute the following commands to add the AdoptOpenJDK APT repos
 .. code-block:: console
 
     sudo apt update
-    sudo apt install apt-transport-https software-properties-common gnupg
+    sudo apt install apt-transport-https software-properties-common gnupg wget
     wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
     sudo add-apt-repository https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
     sudo apt install adoptopenjdk-16-hotspot

--- a/source/java-update/index.rst
+++ b/source/java-update/index.rst
@@ -145,8 +145,17 @@ Debian/Ubuntu
 =============
 
 To install Java 16 on Debian, Ubuntu, and the plethora of other distributions
-based on these, you should follow `AdoptOpenJDK's own DEB installation guide
-here <https://adoptopenjdk.net/installation.html?variant=openjdk16&jvmVariant=hotspot#linux-pkg-deb>`_.
+based on these, execute the following commands to add the AdoptOpenJDK APT repository and to install AdoptOpenJDK Hotspot:
+
+.. code-block:: console
+
+    sudo apt update
+    sudo apt install apt-transport-https software-properties-common gnupg
+    wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+    sudo add-apt-repository https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+    sudo apt install adoptopenjdk-16-hotspot
+    
+You can also replace ``16`` with ``11`` for Java 11.
 
 Arch Linux
 ==========


### PR DESCRIPTION
These are the same commands taken from the original AdoptOpenJDK website before they changed the page to show different commands.

The reasoning for the change is that this is a more user-friendly / easier way to install AdoptOpenJDK on Debian-based distributions. I prefer this set of commands as it requires virtually no additional user input (unlike AdoptOpenJDK's guide). It is likely less confusing for users who are incapable of reading and just copy-paste stuff.