### PR TITLE
update `seed-based-feature-search-loads-chunks` to reflect recent change

### DIFF
--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -20,7 +20,7 @@ their respective documentation pages.
     information here to be incomplete. If you cannot find what you're looking for
     or think something may be wrong, :doc:`../about/contact`
 
-    Last updated June 8th, 2021 for MC 1.16.5, Paper build #766
+    Last updated June 24th, 2021 for MC 1.16.5, Paper build #778
 
 Global Settings
 ===============

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -1134,11 +1134,12 @@ seed-based-feature-search
 
 seed-based-feature-search-loads-chunks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   - **default**: false
+   - **default**: true
    - **description**: When set to false, ``seed-based-feature-search`` will
      not load the target chunk. Instead, it will return the center of the
      chunk. The more precise location of the feature will be returned as the
-     player loads the target chunk.
+     player loads the target chunk. While disabling this will increase
+     performance, it may lead to incorrect feature locations being returned.
 
 allow-using-signs-inside-spawn-protection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
adds a warning about `seed-based-feature-search-loads-chunks` and updates default

recent change: https://github.com/PaperMC/Paper/commit/903fa9a33fcaab03e67343d010558c738bcea84e