### PR TITLE
Add named entity death setting

### DIFF
--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -135,6 +135,12 @@ save-empty-scoreboard-teams
   teams around, dramatically slowing down login times. This sets whether the
   server should remove those empty teams automatically.
 
+log-named-entity-deaths
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* **default**: true
+* **description**:  Since 1.17.1, all deaths of named entities are logged. 
+  This setting allows you to control this behavior. 
+
 velocity-support
 ~~~~~~~~~~~~~~~~
 * enabled


### PR DESCRIPTION
Adds the config setting for the named entity deaths setting (Paper PR: https://github.com/PaperMC/Paper/pull/6107)