### PR TITLE
Update per-player-mob-spawns documentation to reduce confusion

### DIFF
--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -359,7 +359,10 @@ per-player-mob-spawns
 ~~~~~~~~~~~~~~~~~~~~~
 * **default**: false
 * **description**: Determines whether the mob limit (in bukkit.yml) is counted
-  per-player or for the entire server.
+  per-player or for the entire server. Enabling this setting results in roughly
+  the same number of mobs, but with a more even distribution that prevents one
+  player from using the entire mob cap and provides a more single-player like
+  experience.
 
 baby-zombie-movement-modifier
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Many people have been under the impression that this setting multiplies the mob cap by the number of players and uses that instead (which wouldn't even make sense as that would mean you can normally only have 70 monsters, but I digress).