### PR TITLE
add RPM-based distros to java update guide

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Sphinx==4.1.0
 sphinx-rtd-theme==0.5.2
+sphinx-tabs==3.1.0
 sphinx-autobuild==2021.3.14
 docutils==0.16 # https://github.com/readthedocs/sphinx_rtd_theme/issues/1115

--- a/source/conf.py
+++ b/source/conf.py
@@ -31,7 +31,8 @@ sys.path.append(os.path.abspath('../exts'))
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.doctest'
+    'sphinx.ext.doctest',
+    'sphinx_tabs.tabs'
 ]
 
 # github config

--- a/source/java-update/index.rst
+++ b/source/java-update/index.rst
@@ -187,6 +187,38 @@ based on these, execute the following commands to add the AdoptOpenJDK APT repos
     
 You can also replace ``16`` with ``11`` for Java 11.
 
+RPM-Based
+=========
+
+To install Java 16 on CentOS, RHEL, Fedora, openSUSE, SLES and many other RPM-based
+distributions, execute the following commands to add Amazon Corretto's
+RPM repository and install Java 16.
+
+.. tabs::
+
+  .. tab:: DNF
+
+    .. code-block:: console
+
+      $ sudo rpm --import https://yum.corretto.aws/corretto.key
+      $ sudo curl -Lo /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
+      $ sudo dnf -y install java-16-amazon-corretto-devel
+
+  .. tab:: zypper
+
+    .. code-block:: console
+
+      $ sudo zypper addrepo https://yum.corretto.aws/corretto.repo
+      $ sudo zypper install java-16-amazon-corretto-devel
+
+  .. tab:: yum
+
+    .. code-block:: console
+
+      $ sudo rpm --import https://yum.corretto.aws/corretto.key
+      $ sudo curl -Lo /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
+      $ sudo yum -y install java-16-amazon-corretto-devel
+
 Arch Linux
 ==========
 


### PR DESCRIPTION
This uses corretto specifically for RPM-based distros as Adopt's packaging makes it harder to idiot-proof, and is not up to date with modern releases, for example install will fail on openSUSE 15.3 using their instructions without manually modifying it to grab packages for 15.2, which is more complicated than I'd like to put here. yum/dnf also do not seem to have a variable for distro name like they do for release and architecture, making more manual editing required.

This also adds the tabs plugin, which looks like this:
![tabs](https://i.imgur.com/rX8z9PE.gif)

Another consideration is which package managers to include, the main ones being DNF, yum, and zypper. I made the decision here to include both dnf and yum, defaulting to dnf as that's hopefully what most people will be running (eg. not cent 6), and it seems that's what newer releases want you to use for the eventual removal/further deprecation of yum.