### PR TITLE
Remove the "last modified" date on the top of the config

### DIFF
--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -20,8 +20,6 @@ their respective documentation pages.
     information here to be incomplete. If you cannot find what you're looking for
     or think something may be wrong, :doc:`../about/contact`
 
-    Last updated Sep 3rd, 2021 for MC 1.17.1, Paper build #249
-
 Global Settings
 ===============
 


### PR DESCRIPTION
It's now a rolling change, we essentially require it every Paper PR, so "last updated" always changes and is useless as it's usually always accurate.

The alternative I can think of if needed is to add when the config option was added. However, we always encourage people to update, so I don't see a _huge_ need.