### PR TITLE
show last update time for every page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-Sphinx==4.1.2
-sphinx-rtd-theme==1.0.0rc1
+Sphinx==4.2.0
+sphinx-rtd-theme==1.0.0
 sphinx-tabs==3.2.0
 sphinx-autobuild==2021.3.14
 sphinxext-opengraph==0.4.2
+sphinx-last-updated-by-git==0.3.0

--- a/source/conf.py
+++ b/source/conf.py
@@ -33,7 +33,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx_tabs.tabs',
-    'sphinxext.opengraph'
+    'sphinxext.opengraph',
+    'sphinx_last_updated_by_git'
 ]
 
 # opengraph config


### PR DESCRIPTION
Replaces the commit hash for each page with the commit date. For #122. This is per-page, not just the last commit date for the whole docs.
![image](https://user-images.githubusercontent.com/76139600/137570311-1739daf2-8d8a-4c25-9397-6fbc200d8b7a.png)
![image](https://user-images.githubusercontent.com/76139600/137570314-887533fb-2f41-4740-9114-4cfbc0f3f5db.png)
