### PR TITLE
Remove unused wither bug config

### DIFF
--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -1306,11 +1306,6 @@ mobs-can-always-pick-up-loot
   ..
     vim: set ff=unix autoindent ts=4 sw=4 tw=0 et :
 
-fix-wither-targeting-bug
-~~~~~~~~~~~~~~~~~~~~~~~~
-   - **default**: false
-   - **description**: Fixes the wither's targeting of players. See `MC-29274 <https://bugs.mojang.com/browse/MC-29274>`_.
-
 map-item-frame-cursor-limit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    - **default**: 128


### PR DESCRIPTION
This PR remove a config related to a patch removed since 1.18 because mojang already fix this.
https://bugs.mojang.com/browse/MC-29274
https://github.com/PaperMC/Paper/blob/master/patches/removed/1.18/No%20longer%20needed/0626-MC-29274-Fix-Wither-hostility-towards-players.patch