### PR TITLE
Correct default value for item obfuscation

### DIFF
--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -1350,7 +1350,7 @@ anticheat
 * obfuscation
     * items
         * hide-itemmeta
-            - **default**: true
+            - **default**: false
             - **description**: Controls whether unnecessary item information
               (such as enchantments, items in a shulker box/bundle, etc.)
               that can give cheat clients an advantage should be sent to other


### PR DESCRIPTION
Kenny changed the default to false in [this commit](https://github.com/PaperMC/Paper/commit/892c292dc9c712332671966965b1f508d41471b4).