### PR TITLE
Improve async-chunks documentation

### DIFF
--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -240,7 +240,7 @@ async-chunks
 * threads
     - **default**: -1
     - **description**: The number of threads the server should use for world
-      saving and loading. The default `-1` indicates that Paper will utilize half your system's threads for chunk loading unless otherwise specified.
+      saving and loading. The default `-1` indicates that Paper will utilize half your system's threads for chunk loading unless otherwise specified. There is also a maximum default of 4 threads used for saving and loading of chunks. This can be overridden by adding `-Dpaper.maxChunkThreads=[number of threads]` to your JVM flags (and of course replacing `[number of threads]` with the number of threads you desire).
 
 messages
 ~~~~~~~~

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -240,7 +240,7 @@ async-chunks
 * threads
     - **default**: -1
     - **description**: The number of threads the server should use for world
-      saving and loading. This is set to (number of processors - 1) by default.
+      saving and loading. The default `-1` indicates that Paper will utilize half your system's threads for chunk loading unless otherwise specified.
 
 messages
 ~~~~~~~~

--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -239,8 +239,12 @@ async-chunks
 ~~~~~~~~~~~~
 * threads
     - **default**: -1
-    - **description**: The number of threads the server should use for world
-      saving and loading. The default `-1` indicates that Paper will utilize half your system's threads for chunk loading unless otherwise specified. There is also a maximum default of 4 threads used for saving and loading of chunks. This can be overridden by adding `-Dpaper.maxChunkThreads=[number of threads]` to your JVM flags (and of course replacing `[number of threads]` with the number of threads you desire).
+    - **description**: The number of threads the server should use for world saving and loading.
+      The default ``-1`` indicates that Paper will utilize half your system's threads for chunk
+      loading unless otherwise specified. There is also a maximum default of 4 threads used for
+      saving and loading of chunks. This can be overridden by adding
+      ``-Dpaper.maxChunkThreads=[number of threads]`` to your JVM flags (and of course replacing
+      ``[number of threads]`` with the number of threads you desire).
 
 messages
 ~~~~~~~~


### PR DESCRIPTION
Paper's documentation in relation to the `async-chunks` config option seemed to be misleading when looking at the actual code:
```java
int threads = getInt("settings.async-chunks.threads", -1);
int cpus = Runtime.getRuntime().availableProcessors() / 2;
if (threads <= 0) {
    if (cpus <= 4) {
        threads = cpus <= 2 ? 1 : 2;
    } else {
        threads = (int) Math.min(Integer.getInteger("paper.maxChunkThreads", 4), cpus / 2);
    }
}
```