### PR TITLE
Document 'hopper.ignore-occluding-blocks'

### DIFF
--- a/source/server/configuration.rst
+++ b/source/server/configuration.rst
@@ -1133,6 +1133,12 @@ hopper
       hoppers. Dramatically improves hopper performance but will break
       protection plugins and any others that depend on this event.
 
+* ignore-occluding-blocks
+    - **default**: false
+    - **description**: Determines if hoppers will ignore containers inside
+      occluding blocks, like a hopper minecart inside a sand block. Enabling
+      this will improve performance for hoppers checking where to insert items.
+
 anti-xray
 ~~~~~~~~~
 


### PR DESCRIPTION
The default is set to "false" here because there is an open PR on Paper to change the default value.

Paper PR: https://github.com/PaperMC/Paper/pull/7342